### PR TITLE
Bhagya/test-suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,23 @@ pnpm format
 pnpm format:check
 ```
 
+### Testing
+
+This project uses [Vitest](https://vitest.dev/) for unit testing. The testing philosophy is to test each command in complete isolation by mocking its dependencies (like file system access and loggers). This ensures that tests are fast, reliable, and don't have side effects.
+
+Tests are located in the `tests/` directory and follow the naming convention `*.test.ts`.
+
+```bash
+# Run the entire test suite once
+pnpm test
+
+# Run tests in watch mode
+pnpm test:watch
+
+# Run tests and generate a coverage report
+pnpm coverage
+```
+
 ## Usage
 
 ### Connect to a Database

--- a/changelog/1.0.3.md
+++ b/changelog/1.0.3.md
@@ -1,0 +1,28 @@
+---
+title: Version 1.0.3
+---
+
+## Version 1.0.3
+
+This version focuses on major stability improvements and increased test coverage.
+
+### Fixed
+
+- Resolved persistent memory leaks and hanging processes in the Vitest test suite by fixing an infinite loop in the `manage` command's test and ensuring proper resource cleanup.
+- Corrected several test failures caused by improper mocking of ESM modules, particularly `fs` and `@inquirer/prompts`.
+- Stabilized the test environment by adding `process.exit` spies to tests expecting failures, preventing the test runner from crashing.
+- Modified the `stdin` handling for child processes (`pg_dump`, `pg_restore`) to `ignore` instead of `inherit`, preventing deadlocks in the non-interactive test environment.
+
+### Added
+
+- Significantly improved test coverage for the `dump` and `restore` commands, adding tests for numerous edge cases, including:
+    - No databases or dump files found.
+    - Dump file verification failures.
+    - User cancellation of confirmation prompts.
+    - Invalid user input in interactive flows.
+- Added a global test timeout to `vitest.config.ts` to prevent any future tests from hanging indefinitely.
+
+### Changed
+
+- Updated the `pnpm test` script to include the `run` command, ensuring Vitest exits automatically after tests are complete.
+- Removed the unnecessary `--max-old-space-size` flag from the test script, as the underlying memory leaks have been fixed.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dbmux",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "A flexible database management CLI tool with persistent configuration",
     "type": "module",
     "main": "dist/index.js",
@@ -31,7 +31,7 @@
         "format:check": "prettier --check .",
         "format": "prettier --write .",
         "prepublishOnly": "pnpm run clean && pnpm run build",
-        "test": "vitest",
+        "test": "vitest run",
         "test:watch": "vitest --watch",
         "coverage": "vitest run --coverage",
         "prepare": "husky"
@@ -61,6 +61,7 @@
         "@types/pg": "^8.15.4",
         "@typescript-eslint/eslint-plugin": "^8.35.1",
         "@typescript-eslint/parser": "^8.35.1",
+        "@vitest/coverage-v8": "3.2.4",
         "eslint": "^9.30.1",
         "eslint-config-prettier": "^10.1.5",
         "globals": "^16.3.0",

--- a/package.json
+++ b/package.json
@@ -23,15 +23,17 @@
     "scripts": {
         "dev": "tsx src/index.ts",
         "dev:watch": "tsx watch src/index.ts",
-        "build": "tsc",
+        "build": "tsc -p tsconfig.build.json",
         "start": "node dist/index.js",
         "clean": "rm -rf dist",
-        "typecheck": "tsc --noEmit",
+        "typecheck": "tsc --noEmit -p tsconfig.json",
         "lint": "eslint . --ext .ts",
         "format:check": "prettier --check .",
         "format": "prettier --write .",
         "prepublishOnly": "pnpm run clean && pnpm run build",
-        "test": "echo \"Error: no test specified\" && exit 1",
+        "test": "vitest",
+        "test:watch": "vitest --watch",
+        "coverage": "vitest run --coverage",
         "prepare": "husky"
     },
     "keywords": [
@@ -65,9 +67,11 @@
         "husky": "^9.1.7",
         "lint-staged": "^16.1.2",
         "prettier": "^3.6.2",
+        "ts-mockito": "^2.6.1",
         "tsx": "^4.20.3",
         "typescript": "^5.8.3",
-        "typescript-eslint": "^8.35.1"
+        "typescript-eslint": "^8.35.1",
+        "vitest": "^3.2.4"
     },
     "dependencies": {
         "@drizzle-team/brocli": "^0.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      ts-mockito:
+        specifier: ^2.6.1
+        version: 2.6.1
       tsx:
         specifier: ^4.20.3
         version: 4.20.3
@@ -78,6 +81,9 @@ importers:
       typescript-eslint:
         specifier: ^8.35.1
         version: 8.35.1(eslint@9.30.1)(typescript@5.8.3)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.0.10)(tsx@4.20.3)(yaml@2.8.0)
 
 packages:
 
@@ -421,6 +427,9 @@ packages:
       '@types/node':
         optional: true
 
+  '@jridgewell/sourcemap-codec@1.5.4':
+    resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -433,8 +442,114 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@rollup/rollup-android-arm-eabi@4.44.2':
+    resolution: {integrity: sha512-g0dF8P1e2QYPOj1gu7s/3LVP6kze9A7m6x0BZ9iTdXK8N5c2V7cpBKHV3/9A4Zd8xxavdhK0t4PnqjkqVmUc9Q==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.44.2':
+    resolution: {integrity: sha512-Yt5MKrOosSbSaAK5Y4J+vSiID57sOvpBNBR6K7xAaQvk3MkcNVV0f9fE20T+41WYN8hDn6SGFlFrKudtx4EoxA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.44.2':
+    resolution: {integrity: sha512-EsnFot9ZieM35YNA26nhbLTJBHD0jTwWpPwmRVDzjylQT6gkar+zenfb8mHxWpRrbn+WytRRjE0WKsfaxBkVUA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.44.2':
+    resolution: {integrity: sha512-dv/t1t1RkCvJdWWxQ2lWOO+b7cMsVw5YFaS04oHpZRWehI1h0fV1gF4wgGCTyQHHjJDfbNpwOi6PXEafRBBezw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.44.2':
+    resolution: {integrity: sha512-W4tt4BLorKND4qeHElxDoim0+BsprFTwb+vriVQnFFtT/P6v/xO5I99xvYnVzKWrK6j7Hb0yp3x7V5LUbaeOMg==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.44.2':
+    resolution: {integrity: sha512-tdT1PHopokkuBVyHjvYehnIe20fxibxFCEhQP/96MDSOcyjM/shlTkZZLOufV3qO6/FQOSiJTBebhVc12JyPTA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.44.2':
+    resolution: {integrity: sha512-+xmiDGGaSfIIOXMzkhJ++Oa0Gwvl9oXUeIiwarsdRXSe27HUIvjbSIpPxvnNsRebsNdUo7uAiQVgBD1hVriwSQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.44.2':
+    resolution: {integrity: sha512-bDHvhzOfORk3wt8yxIra8N4k/N0MnKInCW5OGZaeDYa/hMrdPaJzo7CSkjKZqX4JFUWjUGm88lI6QJLCM7lDrA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.44.2':
+    resolution: {integrity: sha512-NMsDEsDiYghTbeZWEGnNi4F0hSbGnsuOG+VnNvxkKg0IGDvFh7UVpM/14mnMwxRxUf9AdAVJgHPvKXf6FpMB7A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.44.2':
+    resolution: {integrity: sha512-lb5bxXnxXglVq+7imxykIp5xMq+idehfl+wOgiiix0191av84OqbjUED+PRC5OA8eFJYj5xAGcpAZ0pF2MnW+A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.44.2':
+    resolution: {integrity: sha512-Yl5Rdpf9pIc4GW1PmkUGHdMtbx0fBLE1//SxDmuf3X0dUC57+zMepow2LK0V21661cjXdTn8hO2tXDdAWAqE5g==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.44.2':
+    resolution: {integrity: sha512-03vUDH+w55s680YYryyr78jsO1RWU9ocRMaeV2vMniJJW/6HhoTBwyyiiTPVHNWLnhsnwcQ0oH3S9JSBEKuyqw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.44.2':
+    resolution: {integrity: sha512-iYtAqBg5eEMG4dEfVlkqo05xMOk6y/JXIToRca2bAWuqjrJYJlx/I7+Z+4hSrsWU8GdJDFPL4ktV3dy4yBSrzg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.44.2':
+    resolution: {integrity: sha512-e6vEbgaaqz2yEHqtkPXa28fFuBGmUJ0N2dOJK8YUfijejInt9gfCSA7YDdJ4nYlv67JfP3+PSWFX4IVw/xRIPg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.44.2':
+    resolution: {integrity: sha512-evFOtkmVdY3udE+0QKrV5wBx7bKI0iHz5yEVx5WqDJkxp9YQefy4Mpx3RajIVcM6o7jxTvVd/qpC1IXUhGc1Mw==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.44.2':
+    resolution: {integrity: sha512-/bXb0bEsWMyEkIsUL2Yt5nFB5naLAwyOWMEviQfQY1x3l5WsLKgvZf66TM7UTfED6erckUVUJQ/jJ1FSpm3pRQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.44.2':
+    resolution: {integrity: sha512-3D3OB1vSSBXmkGEZR27uiMRNiwN08/RVAcBKwhUYPaiZ8bcvdeEwWPvbnXvvXHY+A/7xluzcN+kaiOFNiOZwWg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-win32-arm64-msvc@4.44.2':
+    resolution: {integrity: sha512-VfU0fsMK+rwdK8mwODqYeM2hDrF2WiHaSmCBrS7gColkQft95/8tphyzv2EupVxn3iE0FI78wzffoULH1G+dkw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.44.2':
+    resolution: {integrity: sha512-+qMUrkbUurpE6DVRjiJCNGZBGo9xM4Y0FXU5cjgudWqIBWbcLkjE3XprJUsOFgC6xjBClwVa9k6O3A7K3vxb5Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.44.2':
+    resolution: {integrity: sha512-3+QZROYfJ25PDcxFF66UEk8jGWigHJeecZILvkPkyQN7oc5BvFo4YEXFkOs154j3FTMp9mn9Ky8RCOwastduEA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
   '@types/command-exists@1.2.3':
     resolution: {integrity: sha512-PpbaE2XWLaWYboXD6k70TcXO/OdOyyRFq5TVpmlUELNxdkkmXU9fkImNosmXU1DtsNrqdUgWd/nJQYXgwmtdXQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -511,6 +626,35 @@ packages:
     resolution: {integrity: sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -554,6 +698,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -571,9 +719,17 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  chai@5.2.1:
+    resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -585,6 +741,10 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -635,6 +795,10 @@ packages:
       supports-color:
         optional: true
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -647,6 +811,9 @@ packages:
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   esbuild@0.25.5:
     resolution: {integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==}
@@ -701,12 +868,19 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
 
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
@@ -730,6 +904,14 @@ packages:
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  fdir@6.4.6:
+    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -837,6 +1019,9 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -883,9 +1068,18 @@ packages:
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
+
+  loupe@3.1.4:
+    resolution: {integrity: sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==}
+
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -916,6 +1110,11 @@ packages:
   nano-spawn@1.0.2:
     resolution: {integrity: sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg==}
     engines: {node: '>=20.17'}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -952,6 +1151,13 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   pg-cloudflare@1.2.7:
     resolution: {integrity: sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==}
 
@@ -986,14 +1192,25 @@ packages:
   pgpass@1.0.5:
     resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
 
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
     hasBin: true
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
@@ -1049,6 +1266,11 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rollup@4.44.2:
+    resolution: {integrity: sha512-PVoapzTwSEcelaWGth3uR66u7ZRo6qhPHc0f2uRO9fX6XDVNrIiGYS0Pj9+R8yIIYSD/mCx2b16Ws9itljKSPg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -1068,6 +1290,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -1084,9 +1309,19 @@ packages:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
     engines: {node: '>=18'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   split2@4.2.0:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -1112,6 +1347,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -1119,6 +1357,28 @@ packages:
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.14:
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.3:
+    resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
+    engines: {node: '>=14.0.0'}
 
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -1133,6 +1393,9 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-mockito@2.6.1:
+    resolution: {integrity: sha512-qU9m/oEBQrKq5hwfbJ7MgmVN5Gu6lFnIGWvpxSjrqq6YYEVv+RwVFWySbZMBgazsWqv6ctAyVBpo9TmAxnOEKw==}
 
   tsx@4.20.3:
     resolution: {integrity: sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==}
@@ -1165,9 +1428,87 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.0.3:
+    resolution: {integrity: sha512-y2L5oJZF7bj4c0jgGYgBNSdIu+5HF+m68rn2cQXFbGoShdhV1phX9rbnxy9YXj82aS8MMsCLAAFkRxZeWdldrQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -1458,6 +1799,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.0.10
 
+  '@jridgewell/sourcemap-codec@1.5.4': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -1470,7 +1813,73 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@rollup/rollup-android-arm-eabi@4.44.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.44.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.44.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.44.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.44.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.44.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.44.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.44.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.44.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.44.2':
+    optional: true
+
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
   '@types/command-exists@1.2.3': {}
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -1582,6 +1991,48 @@ snapshots:
       '@typescript-eslint/types': 8.35.1
       eslint-visitor-keys: 4.2.1
 
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.1
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.0.3(@types/node@24.0.10)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.0.3(@types/node@24.0.10)(tsx@4.20.3)(yaml@2.8.0)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.3
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.1.4
+      tinyrainbow: 2.0.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -1622,6 +2073,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   astral-regex@2.0.0: {}
 
   balanced-match@1.0.2: {}
@@ -1639,7 +2092,17 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  cac@6.7.14: {}
+
   callsites@3.1.0: {}
+
+  chai@5.2.1:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.4
+      pathval: 2.0.1
 
   chalk@4.1.2:
     dependencies:
@@ -1649,6 +2112,8 @@ snapshots:
   chalk@5.4.1: {}
 
   chardet@0.7.0: {}
+
+  check-error@2.1.1: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -1691,6 +2156,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  deep-eql@5.0.2: {}
+
   deep-is@0.1.4: {}
 
   emoji-regex@10.4.0: {}
@@ -1698,6 +2165,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   environment@1.1.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   esbuild@0.25.5:
     optionalDependencies:
@@ -1798,9 +2267,15 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@5.0.1: {}
+
+  expect-type@1.2.2: {}
 
   external-editor@3.1.0:
     dependencies:
@@ -1827,6 +2302,10 @@ snapshots:
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
+
+  fdir@6.4.6(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -1908,6 +2387,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  js-tokens@9.0.1: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -1963,6 +2444,8 @@ snapshots:
 
   lodash.truncate@4.4.2: {}
 
+  lodash@4.17.21: {}
+
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.0.0
@@ -1970,6 +2453,12 @@ snapshots:
       slice-ansi: 7.1.0
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
+
+  loupe@3.1.4: {}
+
+  magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   merge2@1.4.1: {}
 
@@ -1993,6 +2482,8 @@ snapshots:
   mute-stream@2.0.0: {}
 
   nano-spawn@1.0.2: {}
+
+  nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
 
@@ -2026,6 +2517,10 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   pg-cloudflare@1.2.7:
     optional: true
@@ -2062,9 +2557,19 @@ snapshots:
     dependencies:
       split2: 4.2.0
 
+  picocolors@1.1.1: {}
+
   picomatch@2.3.1: {}
 
+  picomatch@4.0.2: {}
+
   pidtree@0.6.0: {}
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postgres-array@2.0.0: {}
 
@@ -2099,6 +2604,32 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rollup@4.44.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.44.2
+      '@rollup/rollup-android-arm64': 4.44.2
+      '@rollup/rollup-darwin-arm64': 4.44.2
+      '@rollup/rollup-darwin-x64': 4.44.2
+      '@rollup/rollup-freebsd-arm64': 4.44.2
+      '@rollup/rollup-freebsd-x64': 4.44.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.44.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.44.2
+      '@rollup/rollup-linux-arm64-gnu': 4.44.2
+      '@rollup/rollup-linux-arm64-musl': 4.44.2
+      '@rollup/rollup-linux-loongarch64-gnu': 4.44.2
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.44.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.44.2
+      '@rollup/rollup-linux-riscv64-musl': 4.44.2
+      '@rollup/rollup-linux-s390x-gnu': 4.44.2
+      '@rollup/rollup-linux-x64-gnu': 4.44.2
+      '@rollup/rollup-linux-x64-musl': 4.44.2
+      '@rollup/rollup-win32-arm64-msvc': 4.44.2
+      '@rollup/rollup-win32-ia32-msvc': 4.44.2
+      '@rollup/rollup-win32-x64-msvc': 4.44.2
+      fsevents: 2.3.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -2112,6 +2643,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
 
@@ -2131,7 +2664,13 @@ snapshots:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
 
+  source-map-js@1.2.1: {}
+
   split2@4.2.0: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.9.0: {}
 
   string-argv@0.3.2: {}
 
@@ -2157,6 +2696,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -2169,6 +2712,21 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.14:
+    dependencies:
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.3: {}
+
   tmp@0.0.33:
     dependencies:
       os-tmpdir: 1.0.2
@@ -2180,6 +2738,10 @@ snapshots:
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
+
+  ts-mockito@2.6.1:
+    dependencies:
+      lodash: 4.17.21
 
   tsx@4.20.3:
     dependencies:
@@ -2212,9 +2774,90 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  vite-node@3.2.4(@types/node@24.0.10)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.0.3(@types/node@24.0.10)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.0.3(@types/node@24.0.10)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      esbuild: 0.25.5
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.6
+      rollup: 4.44.2
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      '@types/node': 24.0.10
+      fsevents: 2.3.3
+      tsx: 4.20.3
+      yaml: 2.8.0
+
+  vitest@3.2.4(@types/node@24.0.10)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.0.3(@types/node@24.0.10)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.1
+      debug: 4.4.1
+      expect-type: 1.2.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.0.3(@types/node@24.0.10)(tsx@4.20.3)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@24.0.10)(tsx@4.20.3)(yaml@2.8.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.0.10
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.35.1
         version: 8.35.1(eslint@9.30.1)(typescript@5.8.3)
+      '@vitest/coverage-v8':
+        specifier: 3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@24.0.10)(tsx@4.20.3)(yaml@2.8.0))
       eslint:
         specifier: ^9.30.1
         version: 9.30.1
@@ -86,6 +89,31 @@ importers:
         version: 3.2.4(@types/node@24.0.10)(tsx@4.20.3)(yaml@2.8.0)
 
 packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.28.0':
+    resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.28.0':
+    resolution: {integrity: sha512-jYnje+JyZG5YThjHiF28oT4SIZLnYOcSBb6+SDaFIyzDVSkXQmQQYclJ2R+YxcdmK0AX6x1E5OQNtuh3jHDrUg==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -427,8 +455,26 @@ packages:
       '@types/node':
         optional: true
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.3':
+    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
+    engines: {node: '>=8'}
+
+  '@jridgewell/gen-mapping@0.3.12':
+    resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.4':
     resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
+
+  '@jridgewell/trace-mapping@0.3.29':
+    resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -441,6 +487,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@rollup/rollup-android-arm-eabi@4.44.2':
     resolution: {integrity: sha512-g0dF8P1e2QYPOj1gu7s/3LVP6kze9A7m6x0BZ9iTdXK8N5c2V7cpBKHV3/9A4Zd8xxavdhK0t4PnqjkqVmUc9Q==}
@@ -626,6 +676,15 @@ packages:
     resolution: {integrity: sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
@@ -701,6 +760,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.3:
+    resolution: {integrity: sha512-MuXMrSLVVoA6sYN/6Hke18vMzrT4TZNbZIj/hvh0fnYFpO+/kFXcLIaiPwXXWaQUPg4yJD8fj+lfJ7/1EBconw==}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -802,11 +864,17 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -932,6 +1000,10 @@ packages:
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -952,6 +1024,10 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -966,6 +1042,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -1018,6 +1097,25 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.1.7:
+    resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
@@ -1078,8 +1176,18 @@ packages:
   loupe@3.1.4:
     resolution: {integrity: sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1098,6 +1206,10 @@ packages:
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
@@ -1139,6 +1251,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1150,6 +1265,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -1331,6 +1450,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -1357,6 +1480,10 @@ packages:
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
+
+  test-exclude@7.0.1:
+    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1519,6 +1646,14 @@ packages:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrap-ansi@9.0.0:
     resolution: {integrity: sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==}
     engines: {node: '>=18'}
@@ -1541,6 +1676,26 @@ packages:
     engines: {node: '>=18'}
 
 snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/parser@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.0
+
+  '@babel/types@7.28.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@colors/colors@1.5.0':
     optional: true
@@ -1799,7 +1954,30 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.0.10
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.3': {}
+
+  '@jridgewell/gen-mapping@0.3.12':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/trace-mapping': 0.3.29
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.4': {}
+
+  '@jridgewell/trace-mapping@0.3.29':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.4
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -1812,6 +1990,9 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@rollup/rollup-android-arm-eabi@4.44.2':
     optional: true
@@ -1991,6 +2172,25 @@ snapshots:
       '@typescript-eslint/types': 8.35.1
       eslint-visitor-keys: 4.2.1
 
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@24.0.10)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.3
+      debug: 4.4.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.1.7
+      magic-string: 0.30.17
+      magicast: 0.3.5
+      std-env: 3.9.0
+      test-exclude: 7.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@24.0.10)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.2
@@ -2074,6 +2274,12 @@ snapshots:
   argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.3:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.29
+      estree-walker: 3.0.3
+      js-tokens: 9.0.1
 
   astral-regex@2.0.0: {}
 
@@ -2160,9 +2366,13 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  eastasianwidth@0.2.0: {}
+
   emoji-regex@10.4.0: {}
 
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   environment@1.1.0: {}
 
@@ -2327,6 +2537,11 @@ snapshots:
 
   flatted@3.3.3: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fsevents@2.3.3:
     optional: true
 
@@ -2344,6 +2559,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   globals@14.0.0: {}
 
   globals@16.3.0: {}
@@ -2351,6 +2575,8 @@ snapshots:
   graphemer@1.4.0: {}
 
   has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
 
   husky@9.1.7: {}
 
@@ -2386,6 +2612,33 @@ snapshots:
   is-number@7.0.0: {}
 
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.29
+      debug: 4.4.1
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.1.7:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
 
   js-tokens@9.0.1: {}
 
@@ -2456,9 +2709,21 @@ snapshots:
 
   loupe@3.1.4: {}
 
+  lru-cache@10.4.3: {}
+
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.4
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.2
 
   merge2@1.4.1: {}
 
@@ -2476,6 +2741,8 @@ snapshots:
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
+
+  minipass@7.1.2: {}
 
   ms@2.1.3: {}
 
@@ -2510,6 +2777,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -2517,6 +2786,11 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
 
   pathe@2.0.3: {}
 
@@ -2680,6 +2954,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.4.0
@@ -2711,6 +2991,12 @@ snapshots:
       slice-ansi: 4.0.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  test-exclude@7.0.1:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.4.5
+      minimatch: 9.0.5
 
   tinybench@2.9.0: {}
 
@@ -2866,6 +3152,18 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
 
   wrap-ansi@9.0.0:
     dependencies:

--- a/src/commands/dump.ts
+++ b/src/commands/dump.ts
@@ -79,8 +79,10 @@ export async function executeDumpCommand(options: DumpOptions): Promise<void> {
         }
 
         // Get output filename
-        let outputFile = options.output;
-        if (!outputFile) {
+        let outputFile: string;
+        if (options.output) {
+            outputFile = options.output;
+        } else {
             const defaultName = generateDumpFilename(selectedDatabase);
             logger.info(`Default filename: ${defaultName}`);
 
@@ -90,8 +92,6 @@ export async function executeDumpCommand(options: DumpOptions): Promise<void> {
             });
 
             outputFile = customName || defaultName;
-        } else {
-            outputFile = generateDumpFilename(selectedDatabase, outputFile);
         }
 
         // Confirm dump operation

--- a/src/commands/restore.ts
+++ b/src/commands/restore.ts
@@ -34,7 +34,7 @@ export async function executeRestoreCommand(
         // Validate options
         if (options.file && !fs.existsSync(options.file)) {
             logger.fail(`Dump file not found: ${options.file}`);
-            return;
+            process.exit(1);
         }
 
         // Get connection config
@@ -45,14 +45,14 @@ export async function executeRestoreCommand(
             logger.fail(
                 "No database connection found. Run 'dbmux connect' first."
             );
-            return;
+            process.exit(1);
         }
 
         if (connection.type !== "postgresql") {
             logger.fail(
                 "Restore command is currently only supported for PostgreSQL databases."
             );
-            return;
+            process.exit(1);
         }
 
         // Test connection first
@@ -71,7 +71,7 @@ export async function executeRestoreCommand(
                 logger.info(
                     "Dump files should have extensions: .dump, .sql, .gz, .tar"
                 );
-                return;
+                process.exit(1);
             }
 
             dumpFile = await select({
@@ -92,7 +92,7 @@ export async function executeRestoreCommand(
             await verifyDumpFile(dumpFile);
         } catch {
             logger.fail(`Dump file verification failed.`);
-            return;
+            process.exit(1);
         }
 
         // Select restore target
@@ -153,7 +153,7 @@ export async function executeRestoreCommand(
 
                 if (databases.length === 0) {
                     logger.fail("No databases found");
-                    return;
+                    process.exit(1);
                 }
 
                 targetDatabase = await select({

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -46,3 +46,13 @@ export type TableDetail = {
     columns: ColumnInfo[];
     rowCount: number;
 };
+
+export type DBmuxConfig = {
+    connections: Record<string, ConnectionConfig>;
+    defaultConnection?: string;
+    settings: {
+        logLevel: "debug" | "info" | "warn" | "error";
+        autoConnect: boolean;
+        queryTimeout: number;
+    };
+};

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,23 +1,13 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
-import type { ConnectionConfig } from "../types/database.js";
+import type { ConnectionConfig, DBmuxConfig } from "../types/database.js";
 import { logger } from "../utils/logger.js";
 import { CONFIG_DIR } from "./constants.js";
 import { getActiveConnection } from "./session.js";
 
 const CONFIG_FILE = join(CONFIG_DIR, "config.json");
 
-export type DbmuxConfig = {
-    connections: Record<string, ConnectionConfig>;
-    defaultConnection?: string;
-    settings: {
-        logLevel: "debug" | "info" | "warn" | "error";
-        autoConnect: boolean;
-        queryTimeout: number;
-    };
-};
-
-const DEFAULT_CONFIG: DbmuxConfig = {
+const DEFAULT_CONFIG: DBmuxConfig = {
     connections: {},
     settings: {
         logLevel: "info",
@@ -32,7 +22,7 @@ function ensureConfigDir(): void {
     }
 }
 
-export function loadConfig(): DbmuxConfig {
+export function loadConfig(): DBmuxConfig {
     ensureConfigDir();
 
     if (!existsSync(CONFIG_FILE)) {
@@ -41,7 +31,7 @@ export function loadConfig(): DbmuxConfig {
 
     try {
         const configContent = readFileSync(CONFIG_FILE, "utf-8");
-        const config = JSON.parse(configContent) as DbmuxConfig;
+        const config = JSON.parse(configContent) as DBmuxConfig;
 
         // Merge with defaults to ensure all fields exist
         return {
@@ -60,7 +50,7 @@ export function loadConfig(): DbmuxConfig {
     }
 }
 
-export function saveConfig(config: DbmuxConfig): void {
+export function saveConfig(config: DBmuxConfig): void {
     ensureConfigDir();
 
     try {
@@ -173,7 +163,7 @@ export function setDefaultConnection(name: string): void {
 }
 
 export function updateSettings(
-    settings: Partial<DbmuxConfig["settings"]>
+    settings: Partial<DBmuxConfig["settings"]>
 ): void {
     const config = loadConfig();
     config.settings = { ...config.settings, ...settings };

--- a/src/utils/dump-restore.ts
+++ b/src/utils/dump-restore.ts
@@ -68,7 +68,7 @@ export async function executeCommand(
     return new Promise((resolve) => {
         const childProcess = spawn(command, args, {
             env: { ...process.env, ...env },
-            stdio: ["inherit", "pipe", "pipe"],
+            stdio: ["ignore", "pipe", "pipe"],
         });
 
         let stdout = "";

--- a/tests/commands/config/add.test.ts
+++ b/tests/commands/config/add.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeAddCommand } from "../../../src/commands/config/add";
+import type { ConnectionConfig } from "../../../src/types/database";
+
+const { promptForConnectionDetails } = vi.hoisted(() => ({
+    promptForConnectionDetails: vi.fn(),
+}));
+const { testConnection } = vi.hoisted(() => ({ testConnection: vi.fn() }));
+const { input } = vi.hoisted(() => ({ input: vi.fn() }));
+const { addConnection } = vi.hoisted(() => ({ addConnection: vi.fn() }));
+const { logger } = vi.hoisted(() => ({
+    logger: {
+        info: vi.fn(),
+        fail: vi.fn(),
+        success: vi.fn(),
+    },
+}));
+
+vi.mock("../../../src/utils/prompt.js", () => ({ promptForConnectionDetails }));
+vi.mock("../../../src/utils/database.js", () => ({ testConnection }));
+vi.mock("@inquirer/prompts", () => ({ input }));
+vi.mock("../../../src/utils/config.js", () => ({ addConnection }));
+vi.mock("../../../src/utils/logger.js", () => ({ logger }));
+
+describe("executeAddCommand", () => {
+    const mockPostgresConfig: ConnectionConfig = {
+        type: "postgresql",
+        host: "localhost",
+        port: 5432,
+        user: "test",
+        database: "testdb",
+    };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        promptForConnectionDetails.mockResolvedValue(mockPostgresConfig);
+        testConnection.mockResolvedValue(true);
+    });
+
+    it("should add a new connection with a custom name", async () => {
+        input.mockResolvedValue("my-custom-name");
+        await executeAddCommand();
+
+        expect(promptForConnectionDetails).toHaveBeenCalledOnce();
+        expect(testConnection).toHaveBeenCalledWith(mockPostgresConfig);
+        expect(input).toHaveBeenCalledOnce();
+        expect(addConnection).toHaveBeenCalledWith(
+            "my-custom-name",
+            mockPostgresConfig
+        );
+        expect(logger.success).toHaveBeenCalledWith(
+            "Connection 'my-custom-name' added and saved successfully."
+        );
+    });
+
+    it("should add a new connection with the default name", async () => {
+        input.mockResolvedValue(""); // User presses enter
+        await executeAddCommand();
+
+        const expectedDefaultName = "test@localhost/testdb";
+        expect(addConnection).toHaveBeenCalledWith(
+            expectedDefaultName,
+            mockPostgresConfig
+        );
+        expect(logger.success).toHaveBeenCalledWith(
+            `Connection '${expectedDefaultName}' added and saved successfully.`
+        );
+    });
+
+    it("should fail and not save if the connection test fails", async () => {
+        testConnection.mockResolvedValue(false);
+        await executeAddCommand();
+
+        expect(logger.fail).toHaveBeenCalledWith(
+            "Connection test failed. The connection was not saved. Please check the details and try again."
+        );
+        expect(addConnection).not.toHaveBeenCalled();
+    });
+
+    it("should handle errors when saving the connection", async () => {
+        const saveError = new Error("Disk is full");
+        addConnection.mockImplementation(() => {
+            throw saveError;
+        });
+        input.mockResolvedValue("bad-save");
+
+        await expect(executeAddCommand()).rejects.toThrow(saveError);
+
+        expect(logger.success).toHaveBeenCalledWith(
+            "Connection test successful!"
+        );
+        expect(addConnection).toHaveBeenCalledWith(
+            "bad-save",
+            mockPostgresConfig
+        );
+    });
+});

--- a/tests/commands/config/default.test.ts
+++ b/tests/commands/config/default.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeDefaultCommand } from "../../../src/commands/config/default";
+
+const { listConnections, setDefaultConnection } = vi.hoisted(() => ({
+    listConnections: vi.fn(),
+    setDefaultConnection: vi.fn(),
+}));
+
+const { input } = vi.hoisted(() => ({ input: vi.fn() }));
+const { logger } = vi.hoisted(() => ({
+    logger: {
+        info: vi.fn(),
+        fail: vi.fn(),
+        success: vi.fn(),
+    },
+}));
+
+vi.mock("../../../src/utils/config.js", () => ({
+    listConnections,
+    setDefaultConnection,
+}));
+vi.mock("@inquirer/prompts", () => ({ input }));
+vi.mock("../../../src/utils/logger.js", () => ({ logger }));
+
+describe("executeDefaultCommand", () => {
+    const mockConnections = {
+        "test-1": {},
+        "test-2": {},
+    };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        listConnections.mockReturnValue(mockConnections);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("should inform the user when no connections exist", async () => {
+        listConnections.mockReturnValue({});
+        await executeDefaultCommand();
+        expect(logger.info).toHaveBeenCalledWith(
+            "No saved connections to set as default."
+        );
+        expect(setDefaultConnection).not.toHaveBeenCalled();
+    });
+
+    it("should set the default connection in non-interactive mode", async () => {
+        await executeDefaultCommand("test-1");
+        expect(setDefaultConnection).toHaveBeenCalledWith("test-1");
+        expect(logger.success).toHaveBeenCalledWith(
+            "'test-1' is now the default connection."
+        );
+    });
+
+    it("should prompt for a name if an invalid one is provided non-interactively", async () => {
+        input.mockResolvedValue("test-2");
+        await executeDefaultCommand("non-existent");
+        expect(input).toHaveBeenCalledOnce();
+        expect(setDefaultConnection).toHaveBeenCalledWith("test-2");
+    });
+
+    it("should set the default connection in interactive mode", async () => {
+        input.mockResolvedValue("test-2");
+        await executeDefaultCommand();
+        expect(input).toHaveBeenCalledOnce();
+        expect(setDefaultConnection).toHaveBeenCalledWith("test-2");
+        expect(logger.success).toHaveBeenCalledWith(
+            "'test-2' is now the default connection."
+        );
+    });
+
+    it("should handle errors when setting the default connection", async () => {
+        const error = new Error("Config file is read-only");
+        setDefaultConnection.mockImplementation(() => {
+            throw error;
+        });
+        const processExit = vi
+            .spyOn(process, "exit")
+            .mockImplementation((() => {}) as () => never);
+
+        await executeDefaultCommand("test-1");
+
+        expect(logger.fail).toHaveBeenCalledWith("Config file is read-only");
+        expect(processExit).toHaveBeenCalledWith(1);
+    });
+});

--- a/tests/commands/config/list.test.ts
+++ b/tests/commands/config/list.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeListCommand } from "../../../src/commands/config/list";
+import {
+    type ConnectionConfig,
+    type DBmuxConfig,
+} from "../../../src/types/database";
+
+const { listConnections, loadConfig } = vi.hoisted(() => {
+    return {
+        listConnections: vi.fn(),
+        loadConfig: vi.fn(),
+    };
+});
+
+const { logger } = vi.hoisted(() => {
+    return {
+        logger: {
+            info: vi.fn(),
+            raw: vi.fn(),
+            error: vi.fn(),
+            success: vi.fn(),
+            warn: vi.fn(),
+        },
+    };
+});
+
+vi.mock("../../../src/utils/config.js", () => ({
+    listConnections,
+    loadConfig,
+}));
+
+vi.mock("../../../src/utils/logger.js", () => ({
+    logger,
+}));
+
+describe("executeListCommand", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it("should inform the user when no connections are saved", async () => {
+        listConnections.mockReturnValue({});
+        loadConfig.mockReturnValue({
+            connections: {},
+            defaultConnection: undefined,
+            settings: {
+                autoConnect: false,
+                logLevel: "info",
+                queryTimeout: 30000,
+            },
+        });
+        await executeListCommand();
+
+        expect(logger.info).toHaveBeenCalledWith("No saved connections found");
+        expect(logger.info).toHaveBeenCalledWith(
+            "Use 'dbmux connect' to create a connection"
+        );
+        expect(logger.raw).not.toHaveBeenCalled();
+    });
+
+    it("should list all saved connections and identify the default", async () => {
+        const connections: Record<string, ConnectionConfig> = {
+            "test-pg": {
+                type: "postgresql",
+                host: "localhost",
+                port: 5432,
+                user: "test",
+                database: "testdb",
+                ssl: false,
+            },
+            "test-sqlite": {
+                type: "sqlite",
+                filePath: "test.db",
+            },
+        };
+
+        const config: DBmuxConfig = {
+            connections,
+            defaultConnection: "test-pg",
+            settings: {
+                autoConnect: false,
+                logLevel: "info",
+                queryTimeout: 30000,
+            },
+        };
+
+        listConnections.mockReturnValue(connections);
+        loadConfig.mockReturnValue(config);
+        await executeListCommand();
+
+        expect(logger.info).toHaveBeenCalledWith("\nSaved connections:");
+
+        const rawCalls = logger.raw.mock.calls.flat();
+        expect(rawCalls).toEqual([
+            "\n  test-pg (default)",
+            "    Type: postgresql",
+            "    Host: localhost",
+            "    Port: 5432",
+            "    User: test",
+            "    Database: testdb",
+            "    SSL: Disabled",
+            "\n  test-sqlite",
+            "    Type: sqlite",
+            "    File: test.db",
+            "",
+        ]);
+    });
+});

--- a/tests/commands/config/manage.test.ts
+++ b/tests/commands/config/manage.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeManageCommand } from "../../../src/commands/config/manage";
+
+const { executeAddCommand } = vi.hoisted(() => ({
+    executeAddCommand: vi.fn(),
+}));
+const { executeDefaultCommand } = vi.hoisted(() => ({
+    executeDefaultCommand: vi.fn(),
+}));
+const { executeListCommand } = vi.hoisted(() => ({
+    executeListCommand: vi.fn(),
+}));
+const { executeRemoveCommand } = vi.hoisted(() => ({
+    executeRemoveCommand: vi.fn(),
+}));
+const { executeRenameCommand } = vi.hoisted(() => ({
+    executeRenameCommand: vi.fn(),
+}));
+
+const { select } = vi.hoisted(() => ({ select: vi.fn() }));
+const { logger } = vi.hoisted(() => ({
+    logger: {
+        info: vi.fn(),
+    },
+}));
+
+vi.mock("../../../src/commands/config/add.js", () => ({ executeAddCommand }));
+vi.mock("../../../src/commands/config/default.js", () => ({
+    executeDefaultCommand,
+}));
+vi.mock("../../../src/commands/config/list.js", () => ({ executeListCommand }));
+vi.mock("../../../src/commands/config/remove.js", () => ({
+    executeRemoveCommand,
+}));
+vi.mock("../../../src/commands/config/rename.js", () => ({
+    executeRenameCommand,
+}));
+vi.mock("@inquirer/prompts", () => ({ select }));
+vi.mock("../../../src/utils/logger.js", () => ({ logger }));
+
+describe("executeManageCommand", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("should call executeListCommand when 'list' is selected", async () => {
+        select
+            .mockResolvedValueOnce("list")
+            .mockResolvedValueOnce("continue")
+            .mockResolvedValueOnce("exit");
+
+        await executeManageCommand();
+        expect(executeListCommand).toHaveBeenCalledOnce();
+    });
+
+    it("should call executeAddCommand when 'add' is selected", async () => {
+        select
+            .mockResolvedValueOnce("add")
+            .mockResolvedValueOnce("continue")
+            .mockResolvedValueOnce("exit");
+
+        await executeManageCommand();
+        expect(executeAddCommand).toHaveBeenCalledOnce();
+    });
+
+    it("should call executeRemoveCommand when 'remove' is selected", async () => {
+        select
+            .mockResolvedValueOnce("remove")
+            .mockResolvedValueOnce("continue")
+            .mockResolvedValueOnce("exit");
+
+        await executeManageCommand();
+        expect(executeRemoveCommand).toHaveBeenCalledOnce();
+    });
+
+    it("should call executeRenameCommand when 'rename' is selected", async () => {
+        select
+            .mockResolvedValueOnce("rename")
+            .mockResolvedValueOnce("continue")
+            .mockResolvedValueOnce("exit");
+
+        await executeManageCommand();
+        expect(executeRenameCommand).toHaveBeenCalledOnce();
+    });
+
+    it("should call executeDefaultCommand when 'default' is selected", async () => {
+        select
+            .mockResolvedValueOnce("default")
+            .mockResolvedValueOnce("continue")
+            .mockResolvedValueOnce("exit");
+
+        await executeManageCommand();
+        expect(executeDefaultCommand).toHaveBeenCalledOnce();
+    });
+
+    it("should exit when 'exit' is selected", async () => {
+        select.mockResolvedValueOnce("exit");
+
+        await executeManageCommand();
+        expect(logger.info).toHaveBeenCalledWith("Exiting connection manager.");
+        // Ensure no action commands were called
+        expect(executeListCommand).not.toHaveBeenCalled();
+        expect(executeAddCommand).not.toHaveBeenCalled();
+        // Check that the "continue" prompt was not shown
+        expect(select).toHaveBeenCalledOnce();
+    });
+});

--- a/tests/commands/config/path.test.ts
+++ b/tests/commands/config/path.test.ts
@@ -1,0 +1,32 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executePathCommand } from "../../../src/commands/config/path";
+
+const { getConfigPath } = vi.hoisted(() => ({
+    getConfigPath: vi.fn(),
+}));
+
+const { logger } = vi.hoisted(() => ({
+    logger: {
+        info: vi.fn(),
+    },
+}));
+
+vi.mock("../../../src/utils/config.js", () => ({ getConfigPath }));
+vi.mock("../../../src/utils/logger.js", () => ({ logger }));
+
+describe("executePathCommand", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it("should display the configuration file path", () => {
+        const fakePath = "/home/user/.dbmux/config.json";
+        getConfigPath.mockReturnValue(fakePath);
+
+        executePathCommand();
+
+        expect(logger.info).toHaveBeenCalledWith(
+            `Configuration file location: ${fakePath}`
+        );
+    });
+});

--- a/tests/commands/config/remove.test.ts
+++ b/tests/commands/config/remove.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeRemoveCommand } from "../../../src/commands/config/remove";
+
+const { listConnections, removeConnection } = vi.hoisted(() => ({
+    listConnections: vi.fn(),
+    removeConnection: vi.fn(),
+}));
+
+const { checkbox, confirm } = vi.hoisted(() => ({
+    checkbox: vi.fn(),
+    confirm: vi.fn(),
+}));
+
+const { logger } = vi.hoisted(() => ({
+    logger: {
+        info: vi.fn(),
+        fail: vi.fn(),
+        success: vi.fn(),
+    },
+}));
+
+vi.mock("../../../src/utils/config.js", () => ({
+    listConnections,
+    removeConnection,
+}));
+vi.mock("@inquirer/prompts", () => ({ checkbox, confirm }));
+vi.mock("../../../src/utils/logger.js", () => ({ logger }));
+
+describe("executeRemoveCommand", () => {
+    const mockConnections = {
+        "test-1": {},
+        "test-2": {},
+        "test-3": {},
+    };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        listConnections.mockReturnValue(mockConnections);
+    });
+
+    it("should inform the user when no connections exist", async () => {
+        listConnections.mockReturnValue({});
+        await executeRemoveCommand();
+        expect(logger.info).toHaveBeenCalledWith(
+            "No saved connections to remove."
+        );
+        expect(removeConnection).not.toHaveBeenCalled();
+    });
+
+    it("should remove a specified connection in non-interactive mode", async () => {
+        confirm.mockResolvedValue(true);
+        await executeRemoveCommand("test-1");
+        expect(removeConnection).toHaveBeenCalledWith("test-1");
+        expect(logger.success).toHaveBeenCalledWith(
+            "Connection 'test-1' removed successfully."
+        );
+    });
+
+    it("should fail if a specified connection does not exist", async () => {
+        await executeRemoveCommand("non-existent");
+        expect(logger.fail).toHaveBeenCalledWith(
+            "Connection 'non-existent' not found."
+        );
+        expect(removeConnection).not.toHaveBeenCalled();
+    });
+
+    it("should remove selected connections in interactive mode", async () => {
+        checkbox.mockResolvedValue(["test-2", "test-3"]);
+        confirm.mockResolvedValue(true);
+        await executeRemoveCommand();
+        expect(removeConnection).toHaveBeenCalledWith("test-2");
+        expect(removeConnection).toHaveBeenCalledWith("test-3");
+        expect(logger.success).toHaveBeenCalledTimes(2);
+    });
+
+    it("should cancel removal if user does not confirm", async () => {
+        checkbox.mockResolvedValue(["test-1"]);
+        confirm.mockResolvedValue(false);
+        await executeRemoveCommand();
+        expect(logger.info).toHaveBeenCalledWith(
+            "Removal operation cancelled."
+        );
+        expect(removeConnection).not.toHaveBeenCalled();
+    });
+
+    it("should handle no connections being selected in interactive mode", async () => {
+        checkbox.mockResolvedValue([]);
+        await executeRemoveCommand();
+        expect(logger.info).toHaveBeenCalledWith(
+            "No connections selected for removal."
+        );
+        expect(removeConnection).not.toHaveBeenCalled();
+    });
+
+    it("should handle errors during connection removal", async () => {
+        const error = new Error("Filesystem error");
+        removeConnection.mockImplementation((name: string) => {
+            if (name === "test-1") {
+                throw error;
+            }
+        });
+        confirm.mockResolvedValue(true);
+        await executeRemoveCommand("test-1");
+        expect(logger.fail).toHaveBeenCalledWith(
+            "Failed to remove connection 'test-1': Filesystem error"
+        );
+    });
+});

--- a/tests/commands/config/rename.test.ts
+++ b/tests/commands/config/rename.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeRenameCommand } from "../../../src/commands/config/rename";
+
+const { listConnections, renameConnection } = vi.hoisted(() => ({
+    listConnections: vi.fn(),
+    renameConnection: vi.fn(),
+}));
+
+const { input, select } = vi.hoisted(() => ({
+    input: vi.fn(),
+    select: vi.fn(),
+}));
+const { logger } = vi.hoisted(() => ({
+    logger: {
+        info: vi.fn(),
+        fail: vi.fn(),
+        success: vi.fn(),
+    },
+}));
+
+vi.mock("../../../src/utils/config.js", () => ({
+    listConnections,
+    renameConnection,
+}));
+vi.mock("@inquirer/prompts", () => ({ input, select }));
+vi.mock("../../../src/utils/logger.js", () => ({ logger }));
+
+describe("executeRenameCommand", () => {
+    const mockConnections = {
+        "test-1": {},
+        "test-2": {},
+    };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        listConnections.mockReturnValue(mockConnections);
+    });
+
+    it("should inform the user when no connections exist", async () => {
+        listConnections.mockReturnValue({});
+        await executeRenameCommand();
+        expect(logger.info).toHaveBeenCalledWith(
+            "No saved connections to rename."
+        );
+        expect(renameConnection).not.toHaveBeenCalled();
+    });
+
+    it("should rename in non-interactive mode", async () => {
+        await executeRenameCommand("test-1", "test-renamed");
+        expect(renameConnection).toHaveBeenCalledWith("test-1", "test-renamed");
+        expect(logger.success).toHaveBeenCalledWith(
+            "Connection 'test-1' renamed to 'test-renamed' successfully."
+        );
+        expect(select).not.toHaveBeenCalled();
+        expect(input).not.toHaveBeenCalled();
+    });
+
+    it("should prompt for new name if only old name is provided", async () => {
+        input.mockResolvedValue("test-renamed");
+        await executeRenameCommand("test-1");
+        expect(renameConnection).toHaveBeenCalledWith("test-1", "test-renamed");
+        expect(select).not.toHaveBeenCalled();
+        expect(input).toHaveBeenCalledOnce();
+    });
+
+    it("should prompt for old name if only new name is provided", async () => {
+        select.mockResolvedValue("test-2");
+        await executeRenameCommand(undefined, "test-renamed");
+        expect(renameConnection).toHaveBeenCalledWith("test-2", "test-renamed");
+        expect(select).toHaveBeenCalledOnce();
+        expect(input).not.toHaveBeenCalled();
+    });
+
+    it("should prompt for both names in fully interactive mode", async () => {
+        select.mockResolvedValue("test-1");
+        input.mockResolvedValue("test-renamed");
+        await executeRenameCommand();
+        expect(renameConnection).toHaveBeenCalledWith("test-1", "test-renamed");
+        expect(select).toHaveBeenCalledOnce();
+        expect(input).toHaveBeenCalledOnce();
+    });
+
+    it("should handle errors during rename", async () => {
+        const error = new Error("Permission denied");
+        renameConnection.mockImplementation(() => {
+            throw error;
+        });
+        await executeRenameCommand("test-1", "test-renamed");
+        expect(logger.fail).toHaveBeenCalledWith(
+            "Failed to rename connection: Permission denied"
+        );
+    });
+});

--- a/tests/commands/config/show.test.ts
+++ b/tests/commands/config/show.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeShowCommand } from "../../../src/commands/config/show";
+import type { DBmuxConfig } from "../../../src/types/database";
+
+const { getConfigPath, loadConfig } = vi.hoisted(() => ({
+    getConfigPath: vi.fn(),
+    loadConfig: vi.fn(),
+}));
+
+const { logger } = vi.hoisted(() => ({
+    logger: {
+        info: vi.fn(),
+        raw: vi.fn(),
+    },
+}));
+
+vi.mock("../../../src/utils/config.js", () => ({ getConfigPath, loadConfig }));
+vi.mock("../../../src/utils/logger.js", () => ({ logger }));
+
+describe("executeShowCommand", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it("should display the full configuration details", async () => {
+        const mockConfig: DBmuxConfig = {
+            connections: { "test-1": { type: "postgresql" } },
+            defaultConnection: "test-1",
+            settings: {
+                logLevel: "debug",
+                autoConnect: true,
+                queryTimeout: 10000,
+            },
+        };
+        getConfigPath.mockReturnValue("/fake/path/to/config.json");
+        loadConfig.mockReturnValue(mockConfig);
+
+        await executeShowCommand();
+
+        const infoCalls = logger.info.mock.calls.flat();
+        expect(infoCalls).toEqual([
+            "\nConfiguration file: /fake/path/to/config.json",
+            "\nCurrent configuration:",
+            "Settings:",
+            "\nConnections: 1",
+        ]);
+
+        const rawCalls = logger.raw.mock.calls.flat();
+        expect(rawCalls).toEqual([
+            JSON.stringify(mockConfig, null, 2),
+            "",
+            "  Log level: debug",
+            "  Auto connect: true",
+            "  Query timeout: 10000ms",
+            "  Default connection: test-1",
+            "",
+        ]);
+    });
+
+    it("should display correctly with a minimal configuration", async () => {
+        const mockConfig: DBmuxConfig = {
+            connections: {},
+            settings: {
+                logLevel: "info",
+                autoConnect: false,
+                queryTimeout: 30000,
+            },
+        };
+        getConfigPath.mockReturnValue("/fake/path/to/config.json");
+        loadConfig.mockReturnValue(mockConfig);
+
+        await executeShowCommand();
+
+        expect(logger.info).toHaveBeenCalledWith("  Default connection: none");
+        expect(logger.info).toHaveBeenCalledWith("\nConnections: 0");
+    });
+});

--- a/tests/connect.test.ts
+++ b/tests/connect.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeConnectCommand } from "../src/commands/connect";
+
+const { getConnection, listConnections, addConnection } = vi.hoisted(() => ({
+    getConnection: vi.fn(),
+    listConnections: vi.fn(),
+    addConnection: vi.fn(),
+}));
+const { connectToDatabase, testConnection, closeConnection } = vi.hoisted(
+    () => ({
+        connectToDatabase: vi.fn(),
+        testConnection: vi.fn(),
+        closeConnection: vi.fn(),
+    })
+);
+const { promptForConnectionDetails } = vi.hoisted(() => ({
+    promptForConnectionDetails: vi.fn(),
+}));
+const { setActiveConnection } = vi.hoisted(() => ({
+    setActiveConnection: vi.fn(),
+}));
+const { confirm, input, select } = vi.hoisted(() => ({
+    confirm: vi.fn(),
+    input: vi.fn(),
+    select: vi.fn(),
+}));
+const { logger } = vi.hoisted(() => ({
+    logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        fail: vi.fn(),
+        success: vi.fn(),
+    },
+}));
+
+vi.mock("../src/utils/config.js", () => ({
+    getConnection,
+    listConnections,
+    addConnection,
+}));
+vi.mock("../src/utils/database.js", () => ({
+    connectToDatabase,
+    testConnection,
+    closeConnection,
+}));
+vi.mock("../src/utils/prompt.js", () => ({
+    promptForConnectionDetails,
+}));
+vi.mock("../src/utils/session.js", () => ({ setActiveConnection }));
+vi.mock("@inquirer/prompts", () => ({ confirm, input, select }));
+vi.mock("../src/utils/logger.js", () => ({ logger }));
+
+describe("executeConnectCommand", () => {
+    const mockSavedConfig = { type: "postgresql", user: "saved" };
+    const mockNewConfig = { type: "postgresql", user: "new" };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        testConnection.mockResolvedValue(true);
+        listConnections.mockReturnValue({ saved: mockSavedConfig });
+        getConnection.mockReturnValue(mockSavedConfig);
+        promptForConnectionDetails.mockResolvedValue(mockNewConfig);
+    });
+
+    it("should connect using a named connection", async () => {
+        await executeConnectCommand({ name: "saved" });
+        expect(getConnection).toHaveBeenCalledWith("saved");
+        expect(setActiveConnection).toHaveBeenCalledWith("saved");
+        expect(connectToDatabase).toHaveBeenCalledWith(mockSavedConfig);
+        expect(logger.success).toHaveBeenCalledWith(
+            "Connection test successful!"
+        );
+    });
+
+    it("should fall through to interactive if named connection not found", async () => {
+        getConnection.mockImplementation(() => {
+            throw new Error("not found");
+        });
+        select.mockResolvedValue("new");
+        confirm.mockResolvedValue(false); // Don't save
+        await executeConnectCommand({ name: "not-found" });
+        expect(logger.warn).toHaveBeenCalledWith(
+            "Connection 'not-found' not found.  Proceeding to create a new one."
+        );
+        expect(connectToDatabase).toHaveBeenCalledWith(mockNewConfig);
+    });
+
+    it("should allow selecting a saved connection interactively", async () => {
+        select.mockResolvedValue("saved");
+        await executeConnectCommand({});
+        expect(setActiveConnection).toHaveBeenCalledWith("saved");
+        expect(connectToDatabase).toHaveBeenCalledWith(mockSavedConfig);
+    });
+
+    it("should create, save, and connect to a new connection", async () => {
+        select.mockResolvedValue("new");
+        confirm.mockResolvedValue(true);
+        input.mockResolvedValue("my-new-conn");
+        await executeConnectCommand({});
+        expect(addConnection).toHaveBeenCalledWith(
+            "my-new-conn",
+            mockNewConfig
+        );
+        expect(setActiveConnection).toHaveBeenCalledWith("my-new-conn");
+        expect(connectToDatabase).toHaveBeenCalledWith(mockNewConfig);
+    });
+
+    it("should create but not save a new connection", async () => {
+        select.mockResolvedValue("new");
+        confirm.mockResolvedValue(false); // Don't save
+        await executeConnectCommand({});
+        expect(addConnection).not.toHaveBeenCalled();
+        expect(setActiveConnection).not.toHaveBeenCalled(); // Should not be set if not saved
+        expect(connectToDatabase).toHaveBeenCalledWith(mockNewConfig);
+    });
+
+    it("should stop if connection test fails", async () => {
+        testConnection.mockResolvedValue(false);
+        await executeConnectCommand({ name: "saved" });
+        expect(logger.fail).toHaveBeenCalledWith(
+            "Failed to connect. Please check credentials and settings."
+        );
+        expect(connectToDatabase).not.toHaveBeenCalled();
+    });
+
+    it("should not establish connection in test mode", async () => {
+        await executeConnectCommand({ name: "saved", test: true });
+        expect(logger.info).toHaveBeenCalledWith(
+            "Test mode - connection not established."
+        );
+        expect(connectToDatabase).not.toHaveBeenCalled();
+        expect(closeConnection).not.toHaveBeenCalled();
+    });
+});

--- a/tests/disconnect.test.ts
+++ b/tests/disconnect.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeDisconnectCommand } from "../src/commands/disconnect";
+
+const { getActiveConnection, clearActiveConnection } = vi.hoisted(() => ({
+    getActiveConnection: vi.fn(),
+    clearActiveConnection: vi.fn(),
+}));
+const { logger } = vi.hoisted(() => ({
+    logger: {
+        info: vi.fn(),
+        success: vi.fn(),
+    },
+}));
+
+vi.mock("../src/utils/session.js", () => ({
+    getActiveConnection,
+    clearActiveConnection,
+}));
+vi.mock("../src/utils/logger.js", () => ({ logger }));
+
+describe("executeDisconnectCommand", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it("should clear the active connection if one exists", () => {
+        getActiveConnection.mockReturnValue("my-active-session");
+        executeDisconnectCommand();
+        expect(clearActiveConnection).toHaveBeenCalledOnce();
+        expect(logger.success).toHaveBeenCalledWith(
+            "Disconnected from 'my-active-session'. Using default connection now."
+        );
+    });
+
+    it("should inform the user if no active connection exists", () => {
+        getActiveConnection.mockReturnValue(undefined);
+        executeDisconnectCommand();
+        expect(logger.info).toHaveBeenCalledWith(
+            "No active session to disconnect from."
+        );
+        expect(clearActiveConnection).not.toHaveBeenCalled();
+    });
+});

--- a/tests/dump.test.ts
+++ b/tests/dump.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { executeDumpCommand } from "../src/commands/dump";
+
+const { ensureCommandsExist } = vi.hoisted(() => ({
+    ensureCommandsExist: vi.fn(),
+}));
+const { getConnection } = vi.hoisted(() => ({ getConnection: vi.fn() }));
+const { connectToDatabase, getDatabases } = vi.hoisted(() => ({
+    connectToDatabase: vi.fn(),
+    getDatabases: vi.fn(),
+}));
+const { createDatabaseDump, generateDumpFilename } = vi.hoisted(() => ({
+    createDatabaseDump: vi.fn(),
+    generateDumpFilename: vi.fn(),
+}));
+const { confirm, input, select } = vi.hoisted(() => ({
+    confirm: vi.fn(),
+    input: vi.fn(),
+    select: vi.fn(),
+}));
+const { logger } = vi.hoisted(() => ({
+    logger: {
+        info: vi.fn(),
+        fail: vi.fn(),
+        success: vi.fn(),
+    },
+}));
+
+vi.mock("../src/utils/command-check.js", () => ({ ensureCommandsExist }));
+vi.mock("../src/utils/config.js", () => ({ getConnection }));
+vi.mock("../src/utils/database.js", () => ({
+    connectToDatabase,
+    getDatabases,
+}));
+vi.mock("../src/utils/dump-restore.js", () => ({
+    createDatabaseDump,
+    generateDumpFilename,
+}));
+vi.mock("@inquirer/prompts", () => ({ confirm, input, select }));
+vi.mock("../src/utils/logger.js", () => ({ logger }));
+
+describe("executeDumpCommand", () => {
+    const mockConnection = { type: "postgresql" };
+    const mockDatabases = [{ name: "db1" }, { name: "db2" }];
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        ensureCommandsExist.mockReturnValue(true);
+        getConnection.mockReturnValue(mockConnection);
+        getDatabases.mockResolvedValue(mockDatabases);
+        generateDumpFilename.mockReturnValue("default_dump.sql");
+        createDatabaseDump.mockResolvedValue("/path/to/dump.sql");
+        confirm.mockResolvedValue(true);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("should fail if pg_dump is not found", async () => {
+        ensureCommandsExist.mockReturnValue(false);
+        await executeDumpCommand({});
+        expect(logger.fail).not.toHaveBeenCalled(); // The util handles logging
+    });
+
+    it("should fail for non-postgresql connections", async () => {
+        getConnection.mockReturnValue({ type: "sqlite" });
+        await executeDumpCommand({});
+        expect(logger.fail).toHaveBeenCalledWith(
+            "Dump command is currently only supported for PostgreSQL databases."
+        );
+    });
+
+    it("should run non-interactively with all options", async () => {
+        await executeDumpCommand({ database: "db1", output: "custom.sql" });
+        expect(createDatabaseDump).toHaveBeenCalledWith(
+            mockConnection,
+            expect.objectContaining({
+                database: "db1",
+                outputFile: "custom.sql",
+            })
+        );
+        expect(logger.success).toHaveBeenCalledWith(
+            "Dump completed successfully!"
+        );
+    });
+
+    it("should run interactively to select a database", async () => {
+        select.mockResolvedValue("db2");
+        input.mockResolvedValue(""); // use default filename
+        await executeDumpCommand({});
+        expect(select).toHaveBeenCalledOnce();
+        expect(createDatabaseDump).toHaveBeenCalledWith(
+            mockConnection,
+            expect.objectContaining({ database: "db2" })
+        );
+    });
+
+    it("should fail if specified database does not exist", async () => {
+        await executeDumpCommand({ database: "non-existent" });
+        expect(logger.fail).toHaveBeenCalledWith(
+            "Database 'non-existent' not found"
+        );
+    });
+
+    it("should allow user to cancel the dump", async () => {
+        confirm.mockResolvedValue(false);
+        await executeDumpCommand({ database: "db1" });
+        expect(logger.info).toHaveBeenCalledWith("Dump operation cancelled");
+        expect(createDatabaseDump).not.toHaveBeenCalled();
+    });
+
+    it("should handle errors from createDatabaseDump", async () => {
+        const dumpError = new Error("Disk full");
+        createDatabaseDump.mockRejectedValue(dumpError);
+        const processExit = vi
+            .spyOn(process, "exit")
+            .mockImplementation((() => {}) as () => never);
+
+        await executeDumpCommand({ database: "db1" });
+
+        expect(logger.fail).toHaveBeenCalledWith(`Dump failed: ${dumpError}`);
+        expect(processExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should fail if no databases are found", async () => {
+        getDatabases.mockResolvedValue([]);
+        await executeDumpCommand({});
+        expect(logger.fail).toHaveBeenCalledWith("No databases found");
+    });
+
+    it("should use a custom filename when provided interactively", async () => {
+        select.mockResolvedValue("db1");
+        input.mockResolvedValue("my_special_dump.sql"); // Custom filename
+        await executeDumpCommand({});
+        expect(createDatabaseDump).toHaveBeenCalledWith(
+            mockConnection,
+            expect.objectContaining({
+                outputFile: "my_special_dump.sql",
+            })
+        );
+    });
+
+    it("should fail if getting the connection fails", async () => {
+        const connectionError = new Error("No connections found");
+        getConnection.mockImplementation(() => {
+            throw connectionError;
+        });
+        await executeDumpCommand({});
+        expect(logger.fail).toHaveBeenCalledWith(
+            "No database connection found. Run 'dbmux connect' first."
+        );
+    });
+});

--- a/tests/list.test.ts
+++ b/tests/list.test.ts
@@ -1,0 +1,99 @@
+import { table } from "table";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeListCommand } from "../src/commands/list";
+
+const { withDatabaseConnection } = vi.hoisted(() => ({
+    withDatabaseConnection: vi.fn(async (conn, fn, _db) => await fn()),
+}));
+const { listConnections } = vi.hoisted(() => ({ listConnections: vi.fn() }));
+const { getDatabases, getTables } = vi.hoisted(() => ({
+    getDatabases: vi.fn(),
+    getTables: vi.fn(),
+}));
+const { logger } = vi.hoisted(() => ({
+    logger: {
+        info: vi.fn(),
+        fail: vi.fn(),
+        raw: vi.fn(),
+    },
+}));
+vi.mock("table", () => ({ table: vi.fn(() => "mock table") }));
+
+vi.mock("../src/utils/command-runner.js", () => ({
+    withDatabaseConnection,
+}));
+vi.mock("../src/utils/config.js", () => ({ listConnections }));
+vi.mock("../src/utils/database.js", () => ({
+    getDatabases,
+    getTables,
+}));
+vi.mock("../src/utils/logger.js", () => ({ logger }));
+
+describe("executeListCommand", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+    });
+
+    it("should list saved connections", async () => {
+        listConnections.mockReturnValue({ conn1: {}, conn2: {} });
+        await executeListCommand({ connections: true });
+        expect(logger.info).toHaveBeenCalledWith("Saved Connections:");
+        expect(logger.raw).toHaveBeenCalledWith("- conn1");
+        expect(logger.raw).toHaveBeenCalledWith("- conn2");
+    });
+
+    it("should list databases", async () => {
+        getDatabases.mockResolvedValue([
+            { name: "db1", owner: "user1" },
+            { name: "db2", owner: "user2" },
+        ]);
+        await executeListCommand({ databases: true });
+        expect(getDatabases).toHaveBeenCalledOnce();
+        expect(table).toHaveBeenCalledOnce();
+        expect(logger.raw).toHaveBeenCalledWith("mock table");
+    });
+
+    it("should list tables", async () => {
+        getTables.mockResolvedValue(["table1", "table2"]);
+        await executeListCommand({ tables: true });
+        expect(getTables).toHaveBeenCalledOnce();
+        expect(logger.info).toHaveBeenCalledWith("Tables:");
+        expect(logger.raw).toHaveBeenCalledWith("- table1");
+        expect(logger.raw).toHaveBeenCalledWith("- table2");
+    });
+
+    it("should pass schema to getTables", async () => {
+        getTables.mockResolvedValue([]);
+        await executeListCommand({ tables: true, schema: "custom" });
+        expect(getTables).toHaveBeenCalledWith("custom");
+    });
+
+    it("should inform the user if no option is specified", async () => {
+        await executeListCommand({});
+        expect(logger.info).toHaveBeenCalledWith(
+            "No list option specified. Use --databases, --tables, or --connections."
+        );
+    });
+
+    it("should handle no connections found", async () => {
+        listConnections.mockReturnValue({});
+        await executeListCommand({ connections: true });
+        expect(logger.info).toHaveBeenCalledWith(
+            "No saved connections found. Use 'dbmux connect' to add one."
+        );
+    });
+
+    it("should handle no databases found", async () => {
+        getDatabases.mockResolvedValue([]);
+        await executeListCommand({ databases: true });
+        expect(logger.info).toHaveBeenCalledWith("No databases found.");
+    });
+
+    it("should handle no tables found", async () => {
+        getTables.mockResolvedValue([]);
+        await executeListCommand({ tables: true });
+        expect(logger.info).toHaveBeenCalledWith(
+            "No tables found in the current database."
+        );
+    });
+});

--- a/tests/query.test.ts
+++ b/tests/query.test.ts
@@ -1,0 +1,150 @@
+import { readFileSync } from "fs";
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+    type Mock,
+} from "vitest";
+import { executeQueryCommand } from "../src/commands/query";
+import type { QueryResult } from "../src/types/database";
+
+// Mocks
+const { withDatabaseConnection } = vi.hoisted(() => ({
+    withDatabaseConnection: vi.fn(async (connection, callback, database) => {
+        try {
+            return await callback();
+        } catch (error) {
+            // This allows us to catch rejections from executeQuery
+            // and simulate the behavior of the real implementation
+            throw error;
+        }
+    }),
+}));
+const { executeQuery } = vi.hoisted(() => ({
+    executeQuery: vi.fn(),
+}));
+const { logger } = vi.hoisted(() => ({
+    logger: {
+        info: vi.fn(),
+        fail: vi.fn(),
+        success: vi.fn(),
+        raw: vi.fn(),
+        table: vi.fn(), // Added table mock
+    },
+}));
+
+vi.mock("fs", () => ({
+    readFileSync: vi.fn(),
+}));
+
+vi.mock("../src/utils/command-runner.js", () => ({
+    withDatabaseConnection,
+}));
+vi.mock("../src/utils/database.js", () => ({ executeQuery }));
+vi.mock("../src/utils/logger.js", () => ({ logger }));
+vi.mock("cli-table3", () => {
+    const mTable = {
+        push: vi.fn(),
+        toString: vi.fn(() => "mock table"),
+    };
+    return { default: vi.fn(() => mTable) };
+});
+
+describe("executeQueryCommand", () => {
+    const mockQueryResult: QueryResult = {
+        rows: [{ id: 1, name: "test" }],
+        rowCount: 1,
+        fields: ["id", "name"],
+        executionTime: 10,
+    };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        (executeQuery as Mock).mockResolvedValue(mockQueryResult);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("should execute a SQL query and display a table", async () => {
+        await executeQueryCommand({
+            connection: "test",
+            sql: "SELECT * FROM users",
+        });
+        expect(executeQuery).toHaveBeenCalledWith("SELECT * FROM users");
+        expect(logger.raw).toHaveBeenCalledWith("mock table");
+        expect(logger.success).toHaveBeenCalledWith(
+            "Query successful: 1 rows in 10ms"
+        );
+    });
+
+    it("should read a query from a file", async () => {
+        (readFileSync as Mock).mockReturnValue("SELECT * FROM file_users;");
+        await executeQueryCommand({ connection: "test", file: "query.sql" });
+        expect(readFileSync).toHaveBeenCalledWith("query.sql", "utf-8");
+        expect(executeQuery).toHaveBeenCalledWith("SELECT * FROM file_users;");
+    });
+
+    it("should apply a limit to the query", async () => {
+        await executeQueryCommand({
+            connection: "test",
+            sql: "SELECT * FROM users",
+            limit: 50,
+        });
+        expect(executeQuery).toHaveBeenCalledWith(
+            "SELECT * FROM users LIMIT 50"
+        );
+    });
+
+    it("should display results in JSON format", async () => {
+        await executeQueryCommand({
+            connection: "test",
+            sql: "SELECT * FROM users",
+            format: "json",
+        });
+        expect(logger.raw).toHaveBeenCalledWith(
+            JSON.stringify(mockQueryResult.rows, null, 2)
+        );
+    });
+
+    it("should handle query execution failure", async () => {
+        const error = new Error("Query failed");
+        (executeQuery as Mock).mockRejectedValue(error);
+
+        await expect(
+            executeQueryCommand({
+                connection: "test",
+                sql: "SELECT * FROM users",
+            })
+        ).rejects.toThrow(error);
+    });
+
+    it("should handle zero rows returned", async () => {
+        (executeQuery as Mock).mockResolvedValue({
+            ...mockQueryResult,
+            rowCount: 0,
+            rows: [],
+        });
+        await executeQueryCommand({
+            connection: "test",
+            sql: "SELECT * FROM users",
+        });
+        expect(logger.info).toHaveBeenCalledWith("Query returned 0 rows.");
+        expect(logger.table).not.toHaveBeenCalled();
+    });
+
+    it("should fail if no query is provided", async () => {
+        const processExit = vi
+            .spyOn(process, "exit")
+            .mockImplementation((() => {}) as () => never);
+        await executeQueryCommand({ connection: "test" });
+        expect(logger.fail).toHaveBeenCalledWith(
+            "Please provide either a SQL query with -q or a file with -f"
+        );
+        expect(processExit).toHaveBeenCalledWith(1);
+    });
+});

--- a/tests/restore.test.ts
+++ b/tests/restore.test.ts
@@ -1,0 +1,212 @@
+import { existsSync } from "fs";
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+    type Mock,
+} from "vitest";
+import { executeRestoreCommand } from "../src/commands/restore";
+
+// Hoisted Mocks
+const { ensureCommandsExist } = vi.hoisted(() => ({
+    ensureCommandsExist: vi.fn(),
+}));
+const { getConnection } = vi.hoisted(() => ({ getConnection: vi.fn() }));
+const { connectToDatabase, getDatabases } = vi.hoisted(() => ({
+    connectToDatabase: vi.fn(),
+    getDatabases: vi.fn(),
+}));
+const { listDumpFiles, verifyDumpFile, restoreDatabase } = vi.hoisted(() => ({
+    listDumpFiles: vi.fn(),
+    verifyDumpFile: vi.fn(),
+    restoreDatabase: vi.fn(),
+}));
+const { confirm, input, select } = vi.hoisted(() => ({
+    confirm: vi.fn(),
+    input: vi.fn(),
+    select: vi.fn(),
+}));
+const { logger } = vi.hoisted(() => ({
+    logger: {
+        info: vi.fn(),
+        fail: vi.fn(),
+        success: vi.fn(),
+    },
+}));
+
+// Module Mocks
+vi.mock("fs");
+vi.mock("../src/utils/command-check.js", () => ({ ensureCommandsExist }));
+vi.mock("../src/utils/config.js", () => ({ getConnection }));
+vi.mock("../src/utils/database.js", () => ({
+    connectToDatabase,
+    getDatabases,
+}));
+vi.mock("../src/utils/dump-restore.js", () => ({
+    listDumpFiles,
+    verifyDumpFile,
+    restoreDatabase,
+}));
+vi.mock("@inquirer/prompts", () => ({ confirm, input, select }));
+vi.mock("../src/utils/logger.js", () => ({ logger }));
+
+describe("executeRestoreCommand", () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        ensureCommandsExist.mockReturnValue(true);
+        getConnection.mockReturnValue({ type: "postgresql" });
+        listDumpFiles.mockReturnValue([
+            { name: "test.dump", modified: new Date() },
+        ]);
+        getDatabases.mockResolvedValue([{ name: "db1" }]);
+        confirm.mockResolvedValue(true);
+        select.mockResolvedValue("test.dump");
+        (existsSync as Mock).mockReturnValue(true);
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("should fail if pg_restore is not found", async () => {
+        ensureCommandsExist.mockReturnValue(false);
+        await executeRestoreCommand({});
+        expect(restoreDatabase).not.toHaveBeenCalled();
+    });
+
+    it("should fail if dump file does not exist", async () => {
+        const processExit = vi
+            .spyOn(process, "exit")
+            .mockImplementation((() => {}) as () => never);
+        (existsSync as Mock).mockReturnValue(false);
+        await executeRestoreCommand({ file: "bad.dump" });
+        expect(logger.fail).toHaveBeenCalledWith(
+            "Dump file not found: bad.dump"
+        );
+        expect(processExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should restore to a new database interactively", async () => {
+        select
+            .mockResolvedValueOnce("test.dump") // select file
+            .mockResolvedValueOnce("new"); // select action
+        input.mockResolvedValue("new_db"); // enter db name
+        confirm.mockResolvedValue(true); // final confirm
+
+        await executeRestoreCommand({});
+
+        expect(restoreDatabase).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                targetDatabase: "new_db",
+                createDatabase: true,
+            })
+        );
+        expect(logger.success).toHaveBeenCalledWith(
+            "Restore completed successfully!"
+        );
+    });
+
+    it("should restore to an existing database with drop confirmation", async () => {
+        select
+            .mockResolvedValueOnce("test.dump") // select file
+            .mockResolvedValueOnce("existing") // select action
+            .mockResolvedValueOnce("db1"); // select db
+        confirm.mockResolvedValue(true); // confirm dangerous op and final confirm
+
+        await executeRestoreCommand({});
+
+        expect(confirm).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining(
+                    "DANGER: This will DELETE all data"
+                ),
+            })
+        );
+        expect(restoreDatabase).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({
+                targetDatabase: "db1",
+                dropExisting: true,
+            })
+        );
+    });
+
+    it("should cancel if user rejects dangerous confirmation", async () => {
+        select
+            .mockResolvedValueOnce("test.dump")
+            .mockResolvedValueOnce("existing")
+            .mockResolvedValueOnce("db1");
+        confirm.mockResolvedValueOnce(false); // REJECT dangerous op
+
+        await executeRestoreCommand({});
+        expect(logger.info).toHaveBeenCalledWith("Restore operation cancelled");
+        expect(restoreDatabase).not.toHaveBeenCalled();
+    });
+
+    it("should handle restore failure", async () => {
+        const restoreError = new Error("Restore failed");
+        restoreDatabase.mockRejectedValue(restoreError);
+        const processExitSpy = vi
+            .spyOn(process, "exit")
+            .mockImplementation((() => {}) as () => never);
+
+        await executeRestoreCommand({ file: "test.dump", database: "db1" });
+        expect(logger.fail).toHaveBeenCalledWith(
+            expect.stringContaining("Restore failed: Restore failed")
+        );
+        expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it("should fail if no dump files are found", async () => {
+        const processExit = vi
+            .spyOn(process, "exit")
+            .mockImplementation((() => {}) as () => never);
+        listDumpFiles.mockReturnValue([]);
+        await executeRestoreCommand({});
+        expect(logger.fail).toHaveBeenCalledWith(
+            "No dump files found in current directory"
+        );
+        expect(processExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should fail if dump file verification fails", async () => {
+        const processExit = vi
+            .spyOn(process, "exit")
+            .mockImplementation((() => {}) as () => never);
+        const verifyError = new Error("Bad dump file");
+        verifyDumpFile.mockRejectedValue(verifyError);
+        await executeRestoreCommand({ file: "test.dump" });
+        expect(logger.fail).toHaveBeenCalledWith(
+            "Dump file verification failed."
+        );
+        expect(processExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should cancel if user rejects final confirmation", async () => {
+        confirm.mockResolvedValue(false); // Reject final confirmation
+        await executeRestoreCommand({
+            file: "test.dump",
+            database: "db1",
+            drop: true,
+        });
+        expect(logger.info).toHaveBeenCalledWith("Restore operation cancelled");
+        expect(restoreDatabase).not.toHaveBeenCalled();
+    });
+
+    it("should re-prompt for a valid database name", async () => {
+        select.mockResolvedValueOnce("test.dump").mockResolvedValueOnce("new");
+        input.mockResolvedValueOnce("valid_name");
+
+        await executeRestoreCommand({});
+
+        expect(input).toHaveBeenCalledTimes(1);
+        expect(restoreDatabase).toHaveBeenCalledWith(
+            expect.anything(),
+            expect.objectContaining({ targetDatabase: "valid_name" })
+        );
+    });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,10 @@
+import { afterAll, afterEach, vi } from "vitest";
+import { closeConnection } from "../src/utils/database";
+
+afterEach(async () => {
+    await closeConnection();
+});
+
+afterAll(() => {
+    vi.clearAllMocks();
+});

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { executeStatusCommand } from "../src/commands/status";
+import type { DBmuxConfig } from "../src/types/database";
+
+const { loadConfig } = vi.hoisted(() => ({ loadConfig: vi.fn() }));
+const { getActiveConnection } = vi.hoisted(() => ({
+    getActiveConnection: vi.fn(),
+}));
+const { logger } = vi.hoisted(() => ({
+    logger: {
+        info: vi.fn(),
+        fail: vi.fn(),
+        raw: vi.fn(),
+    },
+}));
+
+vi.mock("../src/utils/config.js", () => ({ loadConfig }));
+vi.mock("../src/utils/session.js", () => ({ getActiveConnection }));
+vi.mock("../src/utils/logger.js", () => ({ logger }));
+
+describe("executeStatusCommand", () => {
+    const mockConfig: DBmuxConfig = {
+        connections: {
+            default: { type: "postgresql", user: "default_user" },
+            active: { type: "postgresql", user: "active_user" },
+        },
+        defaultConnection: "default",
+        settings: {
+            logLevel: "info",
+            autoConnect: false,
+            queryTimeout: 30000,
+        },
+    };
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        loadConfig.mockReturnValue(mockConfig);
+    });
+
+    it("should show active connection details when both active and default are set", () => {
+        getActiveConnection.mockReturnValue("active");
+        executeStatusCommand();
+        expect(logger.info).toHaveBeenCalledWith(
+            "Active Connection (current session): active"
+        );
+        expect(logger.raw).toHaveBeenCalledWith("  User: active_user");
+    });
+
+    it("should show default connection details when only default is set", () => {
+        getActiveConnection.mockReturnValue(undefined);
+        executeStatusCommand();
+        expect(logger.info).toHaveBeenCalledWith(
+            "Active Connection (current session): Not set"
+        );
+        expect(logger.raw).toHaveBeenCalledWith("  User: default_user");
+    });
+
+    it("should show a message when neither active nor default is set", () => {
+        loadConfig.mockReturnValue({
+            connections: {},
+            settings: { ...mockConfig.settings },
+        });
+        getActiveConnection.mockReturnValue(undefined);
+        executeStatusCommand();
+        expect(logger.info).toHaveBeenCalledWith(
+            "Default Connection (from config): Not set"
+        );
+        expect(logger.info).toHaveBeenCalledWith(
+            "\nNo active or default connection."
+        );
+    });
+
+    it("should show an error if the connection details are not found", () => {
+        loadConfig.mockReturnValue({
+            ...mockConfig,
+            connections: {}, // No connections in config
+        });
+        getActiveConnection.mockReturnValue("active"); // But an active one is set
+        executeStatusCommand();
+        expect(logger.fail).toHaveBeenCalledWith(
+            "Connection 'active' not found in config file."
+        );
+    });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "noEmit": false
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist", "tests"]
+} 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,6 @@
     "esModuleInterop": true,
     "allowJs": true,
     "checkJs": false,
-    "outDir": "./dist",
-    "rootDir": "./src",
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
@@ -25,15 +23,16 @@
     "sourceMap": true,
     "removeComments": true,
     "resolveJsonModule": true,
-    "types": ["node"]
+    "types": ["node"],
+    "noEmit": true
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "tests/**/*",
+    "vitest.config.ts"
   ],
   "exclude": [
     "node_modules",
-    "dist",
-    "**/*.test.ts",
-    "**/*.spec.ts"
+    "dist"
   ]
 } 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: "node",
+        coverage: {
+            provider: "v8",
+            reporter: ["text", "json", "html"],
+            include: ["src/**/*.ts"],
+            exclude: [
+                "src/index.ts",
+                "src/types/**/*.ts",
+                "src/commands/default.ts",
+            ],
+        },
+    },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,12 @@
+/// <reference types="vitest" />
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
     test: {
         globals: true,
+        setupFiles: ["tests/setup.ts"],
         environment: "node",
+        testTimeout: 10000, // 10 second timeout per test
         coverage: {
             provider: "v8",
             reporter: ["text", "json", "html"],


### PR DESCRIPTION
- Corrects multiple test failures across 'dump', 'list', 'query', and 'restore' commands by updating mocks, assertions, and handling of asynchronous operations.
- Improves error handling in the 'restore' command by using 'process.exit(1)' on failure paths instead of returning, ensuring proper exit codes.
- Updates tests for the 'restore' command to mock 'process.exit', preventing the test runner from terminating prematurely.
- Updates changelog to reflect the comprehensive test suite fixes.